### PR TITLE
Support setting IAM policies on requester-pays buckets

### DIFF
--- a/deploy/config/dam-static/adapter_master_saw_latest.json
+++ b/deploy/config/dam-static/adapter_master_saw_latest.json
@@ -21,18 +21,17 @@
         },
         "bucket": {
           "regexp": "^[a-z]([-a-z0-9]*[a-z0-9])$",
-          "optional": true,
           "ui": {
             "label": "GCS Bucket name",
             "description": "must be owned by the specified project ID"
           }
         },
-        "requester-pays-bucket": {
+        "userProject": {
           "regexp": "^[a-z]([-a-z0-9]*[a-z0-9])$",
           "optional": true,
           "ui": {
-            "label": "GCS Requester Pays Bucket name",
-            "description": "must be owned by the specified project ID"
+            "label": "User Project for requester-pays buckets (IAM requests only)",
+            "description": "this DAM must have service consumer access to this project; used for IAM requests, not data access"
           }
         }
       },

--- a/lib/clouds/resource_token_creator.go
+++ b/lib/clouds/resource_token_creator.go
@@ -29,6 +29,7 @@ type ResourceTokenCreationParams struct {
 	Roles          []string
 	Scopes         []string
 	TokenFormat    string
+	UserProject    string
 }
 
 // ResourceTokenResult is returned from GetTokenWithTTL().


### PR DESCRIPTION
Adds optional `userProject` variable that is used by the SAW adapter when making IAM requests.