### PR TITLE
Added support for specifying a separate project to run bq jobs

### DIFF
--- a/lib/adapter/saw/warehouse.go
+++ b/lib/adapter/saw/warehouse.go
@@ -51,6 +51,7 @@ import (
 const (
 	projectVariable       = "project"
 	bucketVariable        = "bucket"
+	jobProjectVariable    = "job-project"
 	datasetVariable       = "dataset"
 	inheritProject        = "-"
 	gcMaxTTL              = 180 * 24 * 60 * 60 /* 180 days */
@@ -471,6 +472,10 @@ func (wh *AccountWarehouse) configureRoles(ctx context.Context, email string, pa
 				}
 				dr[ds] = append(dr[ds], resolvedRole)
 				resolvedRole = "roles/bigquery.user"
+				jobProj, ok := item[jobProjectVariable]
+				if ok {
+					proj = jobProj
+				}
 			}
 			// Otherwise, store project-level configuration.
 			prMap[proj] = append(prMap[proj], resolvedRole)


### PR DESCRIPTION
A simple change, but add support for specifying a different project for running BQ jobs. This prevents granting `Security Admin` in the project that the data resides in.