### PR TITLE
Added support for specifying a separate project to run bq jobs

### DIFF
--- a/deploy/metadata/adapter_saw.json
+++ b/deploy/metadata/adapter_saw.json
@@ -101,6 +101,15 @@
             "description": "make sure to use the project ID and not the project name"
           }
         },
+        "job-project": {
+          "type": "const",
+          "optional": true,
+          "regexp": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+          "ui": {
+            "label": "Project ID to submit BigQuery jobs to",
+            "description": "make sure to use the project ID and not the project name"
+          }
+        },
         "dataset": {
           "type": "const",
           "regexp": "^[a-z]([-_a-z0-9]*[a-z0-9])?$",

--- a/lib/saw/warehouse.go
+++ b/lib/saw/warehouse.go
@@ -56,6 +56,7 @@ const (
 	projectVariable       = "project"
 	bucketVariable        = "bucket"
 	datasetVariable       = "dataset"
+	jobProjectVariable    = "job-project"
 	inheritProject        = "-"
 	gcMaxTTL              = 180 * 24 * time.Hour /* 180 days */
 	defaultGcFrequency    = 14 * 24 * time.Hour  /* 14 days */
@@ -533,10 +534,15 @@ func parseParams(params *clouds.ResourceTokenCreationParams) (projects map[strin
 					bqdatasets[proj] = dr
 				}
 				dr[ds] = append(dr[ds], resolvedRole)
-				resolvedRole = "roles/bigquery.user"
+				jobProj, ok := item[jobProjectVariable]
+				if ok {
+					proj = jobProj
+				}
+				projects[proj] = append(projects[proj], "roles/bigquery.user")
+				continue
 			}
 
-			// Otherwise, store project-level configuration.
+			// Otherwise, only store project-level configuration.
 			projects[proj] = append(projects[proj], resolvedRole)
 		}
 	}

--- a/lib/saw/warehouse_test.go
+++ b/lib/saw/warehouse_test.go
@@ -421,12 +421,11 @@ func newFix(t *testing.T) (*Fix, func() error) {
 		gcs:  &fakeGCS{},
 		crmState: crmState,
 		bqState: bqState,
+		iamSrv: fakeiam.NewAdmin(),
+		credsSrv: fakeiam.NewCreds(),
 	}
 	f.rpc, cleanup = fakegrpc.New()
-	f.iamSrv = fakeiam.NewAdmin()
 	iamgrpcpb.RegisterIAMServer(f.rpc.Server, f.iamSrv)
-
-	f.credsSrv = fakeiam.NewCreds()
 	iamcredsgrpcpb.RegisterIAMCredentialsServer(f.rpc.Server, f.credsSrv)
 
 	f.rpc.Start()

--- a/lib/saw/warehouse_test.go
+++ b/lib/saw/warehouse_test.go
@@ -419,10 +419,10 @@ func newFix(t *testing.T) (*Fix, func() error) {
 		bqds: &fakeBQ{bqState: bqState},
 		crm:  &fakeCRM{crmState: crmState},
 		gcs:  &fakeGCS{},
+		crmState: crmState,
+		bqState: bqState,
 	}
 	f.rpc, cleanup = fakegrpc.New()
-	f.crmState = crmState
-	f.bqState = bqState
 	f.iamSrv = fakeiam.NewAdmin()
 	iamgrpcpb.RegisterIAMServer(f.rpc.Server, f.iamSrv)
 
@@ -484,9 +484,10 @@ func (f *fakeBQ) Get(ctx context.Context, project string, dataset string) (*bigq
 
 func (f *fakeBQ) Set(ctx context.Context, project string, dataset string, ds *bigquery.Dataset) error {
 	for _, bqd := range ds.Access {
-		a := &bigquery.DatasetAccess{}
-		a.Role = bqd.Role
-		a.UserByEmail = bqd.UserByEmail
+		a := &bigquery.DatasetAccess{
+			Role: bqd.Role,
+			UserByEmail: bqd.UserByEmail,
+		}
 		f.bqState.Access = append(f.bqState.Access, a)
 	}
 	return f.setResponseErr
@@ -519,9 +520,10 @@ func (f *fakeCRM) Get(ctx context.Context, project string) (*cloudresourcemanage
 func (f *fakeCRM) Set(ctx context.Context, project string, policy *cloudresourcemanager.Policy) error {
 	f.crmState.Project = project
 	for _, binding := range policy.Bindings {
-		b := &cloudresourcemanager.Binding{}
-		b.Role = binding.Role
-		b.Members = binding.Members
+		b := &cloudresourcemanager.Binding{
+			Role: binding.Role,
+			Members: binding.Members,
+		}
 		f.crmState.Bindings = append(f.crmState.Bindings, b)
 	}
 	return f.setResponseErr

--- a/lib/saw/warehouse_test.go
+++ b/lib/saw/warehouse_test.go
@@ -19,24 +19,24 @@ import (
 	"testing"
 	"time"
 
-	iamadmin "cloud.google.com/go/iam/admin/apiv1" /* copybara-comment: admin */
-	iamcreds "cloud.google.com/go/iam/credentials/apiv1" /* copybara-comment: credentials */
-	"github.com/google/go-cmp/cmp" /* copybara-comment */
-	"google.golang.org/api/bigquery/v2" /* copybara-comment: bigquery */
-	"google.golang.org/api/cloudresourcemanager/v1" /* copybara-comment: cloudresourcemanager */
-	"google.golang.org/api/option" /* copybara-comment: option */
-	gcs "google.golang.org/api/storage/v1" /* copybara-comment: storage */
-	"google.golang.org/grpc" /* copybara-comment */
-	"google.golang.org/protobuf/testing/protocmp" /* copybara-comment */
-	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/clouds" /* copybara-comment: clouds */
-	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/test/fakegrpc" /* copybara-comment: fakegrpc */
-	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/test/fakeiam" /* copybara-comment: fakeiam */
+	iamadmin "cloud.google.com/go/iam/admin/apiv1"                                           /* copybara-comment: admin */
+	iamcreds "cloud.google.com/go/iam/credentials/apiv1"                                     /* copybara-comment: credentials */
+	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/clouds"         /* copybara-comment: clouds */
+	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/test/fakegrpc"  /* copybara-comment: fakegrpc */
+	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/test/fakeiam"   /* copybara-comment: fakeiam */
 	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/test/fakestore" /* copybara-comment: fakestore */
-	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/timeutil" /* copybara-comment: timeutil */
+	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/timeutil"       /* copybara-comment: timeutil */
+	"github.com/google/go-cmp/cmp"                                                           /* copybara-comment */
+	"google.golang.org/api/bigquery/v2"                                                      /* copybara-comment: bigquery */
+	"google.golang.org/api/cloudresourcemanager/v1"                                          /* copybara-comment: cloudresourcemanager */
+	"google.golang.org/api/option"                                                           /* copybara-comment: option */
+	gcs "google.golang.org/api/storage/v1"                                                   /* copybara-comment: storage */
+	"google.golang.org/grpc"                                                                 /* copybara-comment */
+	"google.golang.org/protobuf/testing/protocmp"                                            /* copybara-comment */
 
-	iamgrpcpb "google.golang.org/genproto/googleapis/iam/admin/v1" /* copybara-comment: iam_go_grpc */
-	iamcredsgrpcpb "google.golang.org/genproto/googleapis/iam/credentials/v1" /* copybara-comment: iamcredentials_go_grpc */
 	cpb "github.com/GoogleCloudPlatform/healthcare-federated-access-services/proto/common/v1" /* copybara-comment: go_proto */
+	iamgrpcpb "google.golang.org/genproto/googleapis/iam/admin/v1"                            /* copybara-comment: iam_go_grpc */
+	iamcredsgrpcpb "google.golang.org/genproto/googleapis/iam/credentials/v1"                 /* copybara-comment: iamcredentials_go_grpc */
 )
 
 func TestNew(t *testing.T) {
@@ -273,6 +273,55 @@ func TestSAW_GetServiceAccounts(t *testing.T) {
 	}
 }
 
+func TestSAW_GetAccountKeyWithRoles_BQ(t *testing.T) {
+	ctx := context.Background()
+
+	fix, cleanup := newFix(t)
+	defer cleanup()
+
+	store := fakestore.New()
+	saw := New(store, fix.iam, fix.creds, fix.crm, fix.gcs, fix.bqds, nil)
+	params := &clouds.ResourceTokenCreationParams{
+		AccountProject: "fake-account-project",
+		Items:          []map[string]string{
+			{   "project": "fake-project-id",
+				"dataset": "fake-dataset",
+				"job-project": "fake-job-project",
+			}},
+		Roles:          []string{"roles/bigquery.dataViewer"},
+		Scopes:         []string{"fake-scope"},
+		BillingProject: "fake-billing-project",
+	}
+
+	if _, err := saw.GetAccountKey(ctx, "fake-id", time.Minute, time.Hour, 100, params); err != nil {
+		t.Errorf("GetAccountKey() failed: %v", err)
+	}
+
+	gotCrm := fix.crmState
+	wantCrm := &crmState{
+		Bindings: []*cloudresourcemanager.Binding{{
+			Members: []string{
+				"serviceAccount:ie652a310ecf7b4ec1771e62d53609@fake-account-project.iam.gserviceaccount.com",
+			},
+			Role: "roles/bigquery.user",
+		}},
+		Project: "fake-job-project",
+	}
+	if diff := cmp.Diff(wantCrm, gotCrm); diff != "" {
+		t.Errorf("saw.GetAccountKeyWithRoles() returned diff (-wantCrm +gotCrm):\n%s", diff)
+	}
+
+	gotBq := fix.bqState.Access
+	wantBq := []*bigquery.DatasetAccess{{
+		Role: "roles/bigquery.dataViewer",
+		UserByEmail: "ie652a310ecf7b4ec1771e62d53609@fake-account-project.iam.gserviceaccount.com",
+	}}
+	if diff := cmp.Diff(wantBq, gotBq); diff != "" {
+		t.Errorf("saw.GetAccountKeyWithRoles() returned diff (-wantBq +gotBq):\n%s", diff)
+	}
+
+}
+
 func TestSAW_RemoveServiceAccount(t *testing.T) {
 	ctx := context.Background()
 
@@ -353,6 +402,8 @@ type Fix struct {
 	bqds     BQPolicy
 	crm      CRMPolicy
 	gcs      GCSPolicy
+	crmState *crmState
+	bqState  *bqState
 }
 
 func newFix(t *testing.T) (*Fix, func() error) {
@@ -362,14 +413,16 @@ func newFix(t *testing.T) (*Fix, func() error) {
 		err     error
 		cleanup func() error
 	)
-
+	crmState := &crmState{Bindings: make([]*cloudresourcemanager.Binding, 0)}
+	bqState  := &bqState{Access: make([]*bigquery.DatasetAccess, 0)}
 	f := &Fix{
-		bqds: &fakeBQ{},
-		crm:  &fakeCRM{},
+		bqds: &fakeBQ{bqState: bqState},
+		crm:  &fakeCRM{crmState: crmState},
 		gcs:  &fakeGCS{},
 	}
 	f.rpc, cleanup = fakegrpc.New()
-
+	f.crmState = crmState
+	f.bqState = bqState
 	f.iamSrv = fakeiam.NewAdmin()
 	iamgrpcpb.RegisterIAMServer(f.rpc.Server, f.iamSrv)
 
@@ -415,13 +468,27 @@ type fakeBQ struct {
 	getResponse    *bigquery.Dataset
 	getResponseErr error
 	setResponseErr error
+	bqState *bqState
+}
+
+type bqState struct {
+	Access []*bigquery.DatasetAccess
 }
 
 func (f *fakeBQ) Get(ctx context.Context, project string, dataset string) (*bigquery.Dataset, error) {
-	return f.getResponse, f.getResponseErr
+	bq := &bigquery.Dataset{
+		Access: []*bigquery.DatasetAccess{},
+	}
+	return bq, f.getResponseErr
 }
 
 func (f *fakeBQ) Set(ctx context.Context, project string, dataset string, ds *bigquery.Dataset) error {
+	for _, bqd := range ds.Access {
+		a := &bigquery.DatasetAccess{}
+		a.Role = bqd.Role
+		a.UserByEmail = bqd.UserByEmail
+		f.bqState.Access = append(f.bqState.Access, a)
+	}
 	return f.setResponseErr
 }
 
@@ -429,12 +496,33 @@ type fakeCRM struct {
 	getResponse    *cloudresourcemanager.Policy
 	getResponseErr error
 	setResponseErr error
+	crmState *crmState
+}
+
+type crmState struct {
+	Bindings []*cloudresourcemanager.Binding
+	Project  string
 }
 
 func (f *fakeCRM) Get(ctx context.Context, project string) (*cloudresourcemanager.Policy, error) {
-	return f.getResponse, f.getResponseErr
+	policy := &cloudresourcemanager.Policy{
+		Bindings: []*cloudresourcemanager.Binding{
+			{
+				Role:    "roles/bigquery.user",
+				Members: []string{"serviceAccount:ie652a310ecf7b4ec1771e62d53609@fake-account-project.iam.gserviceaccount.com"},
+			},
+		},
+	}
+	return policy, f.getResponseErr
 }
 
 func (f *fakeCRM) Set(ctx context.Context, project string, policy *cloudresourcemanager.Policy) error {
+	f.crmState.Project = project
+	for _, binding := range policy.Bindings {
+		b := &cloudresourcemanager.Binding{}
+		b.Role = binding.Role
+		b.Members = binding.Members
+		f.crmState.Bindings = append(f.crmState.Bindings, b)
+	}
 	return f.setResponseErr
 }


### PR DESCRIPTION
Add support for specifying a different project for running BQ jobs. This prevents granting Security Admin in the project that the data resides in. 
This PR has changes from https://github.com/GoogleCloudPlatform/healthcare-federated-access-services/pull/9