### PR TITLE
Add flag to enable AWS target adapter

### DIFF
--- a/gcp/dam/main.go
+++ b/gcp/dam/main.go
@@ -28,6 +28,7 @@ import (
 	"cloud.google.com/go/kms/apiv1" /* copybara-comment: kms */
 	"cloud.google.com/go/logging" /* copybara-comment: logging */
 	"github.com/gorilla/mux" /* copybara-comment */
+	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/globalflags"
 	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/aws" /* copybara-comment: aws */
 	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/dam" /* copybara-comment: dam */
 	"github.com/GoogleCloudPlatform/healthcare-federated-access-services/lib/dsstore" /* copybara-comment: dsstore */
@@ -153,9 +154,12 @@ func main() {
 		}
 	}
 
-	awsClient, err := aws.NewAPIClient()
-	if err != nil {
-		glog.Fatalf("aws.NewAPIClient failed: %v", err)
+	var awsClient aws.APIClient = nil
+	if globalflags.EnableAWSAdapter {
+		awsClient, err = aws.NewAPIClient()
+		if err != nil {
+			glog.Fatalf("aws.NewAPIClient failed: %v", err)
+		}
 	}
 
 	r := mux.NewRouter()

--- a/lib/adapter/adapters.go
+++ b/lib/adapter/adapters.go
@@ -133,9 +133,11 @@ func CreateAdapters(opts *Options) (*ServiceAdapters, error) {
 	registerAdapter(adapters, func(adapters *ServiceAdapters) (ServiceAdapter, error) {
 		return NewGatekeeperAdapter(opts.Signer)
 	})
-	registerAdapter(adapters, func(adapters *ServiceAdapters) (ServiceAdapter, error) {
-		return NewAwsAdapter(opts.Store, opts.AWSClient)
-	})
+	if opts.AWSClient != nil {
+		registerAdapter(adapters, func(adapters *ServiceAdapters) (ServiceAdapter, error) {
+			return NewAwsAdapter(opts.Store, opts.AWSClient)
+		})
+	}
 	registerAdapter(adapters, func(adapters *ServiceAdapters) (ServiceAdapter, error) {
 		return NewAggregatorAdapter(adapters)
 	})

--- a/lib/globalflags/globalflags.go
+++ b/lib/globalflags/globalflags.go
@@ -35,4 +35,8 @@ var (
 	// DisableIAMConditionExpiry is a global flag determining if you want to use IAM condition to manage user IAM expiry.
 	// Set from env var: `export DISABLE_IAM_CONDITION_EXPIRY=true`
 	DisableIAMConditionExpiry = os.Getenv("DISABLE_IAM_CONDITION_EXPIRY") == "true"
+
+	// EnableAWSAdapter is a global flag determining if you want to use enable management of AWS resources.
+	// Set from env var: `export ENABLE_AWS_ADAPTER=true`
+	EnableAWSAdapter = os.Getenv("ENABLE_AWS_ADAPTER") == "true"
 )


### PR DESCRIPTION
Prevents startup errors in deployments without properly configured AWS credentials.